### PR TITLE
Initial version of .html log generation.

### DIFF
--- a/create-html-reports.sh
+++ b/create-html-reports.sh
@@ -88,12 +88,12 @@ fi
 ALL_LOGS=$(find -L $RESULTS_DIR -type f -name "*_log.txt" -print)
 
 for f in $ALL_LOGS; do
-    b=$(basename ${f: 0:-4})
-    html=$(echo $f | sed 's/.txt$/.html/')
+    base_no_extension=$(basename ${f: 0:-4})
+    html=${f: 0:-4}.html
     echo "<!doctype html>
 <html>
 <head>
-   <title>$b</title>
+   <title>$base_no_extension</title>
 <style>
 pre {
     display: inline;
@@ -102,7 +102,7 @@ pre {
 </style>
 </head>
 <body>
-<h1>${b}</h1><br>
+<h1>${base_no_extension}</h1><br>
 " > $html
     awk '{ print "<a id=\""NR"\" href=\"#"NR"\">"NR"</a>: <pre>"$0"</pre><br>"}' $f >> $html
     echo "</body>


### PR DESCRIPTION
Adds detection of `*_log.txt` files and creates a corresponding `*_log.html` file which is just the contents of the log with line numbers and id/anchors that allow sharing of specific lines in the log as a hyperlink.  This also updates the code that generates the `index.html` files accordingly.

html logs look like this:
![image](https://user-images.githubusercontent.com/3039903/128620073-5437c158-fcf2-48f6-a504-68e5088d7e3a.png)

closes #4 