### PR TITLE
Add defaults for common dask-cuda cluster configurations (tcp, ucx+noIB, ucx+IB)

### DIFF
--- a/default-config.sh
+++ b/default-config.sh
@@ -35,6 +35,8 @@ REPO_DIR_NAME=${REPO_DIR_NAME:-repo}
 
 GPUS_PER_NODE=${GPUS_PER_NODE:-8}
 WORKER_RMM_POOL_SIZE=${WORKER_RMM_POOL_SIZE:-12G}
+DASK_CUDA_INTERFACE=${DASK_CUDA_INTERFACE:-ib0}
+DASK_SCHEDULER_PORT=${DASK_SCHEDULER_PORT:-8792}
 
 # There is no default for this, it is here for documentation purposes
 # since RAPIDS_DATASET_ROOT_DIR will be set to it in various test

--- a/default-config.sh
+++ b/default-config.sh
@@ -1,7 +1,7 @@
 THIS_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) && pwd)
 # Most are defined using the bash := or :- syntax, which means they
 # will be set only if they were previously unset. The project config
-# is loaded first, whic hgives it the opportunity to override anything
+# is loaded first, which gives it the opportunity to override anything
 # in this file that uses that syntax.  If there are variables in this
 # file that should not be overridded by a project, then they will
 # simply not use that syntax and override, since these variables are

--- a/run-dask-process.sh
+++ b/run-dask-process.sh
@@ -71,7 +71,6 @@ export DASK_LOGGING__DISTRIBUTED="DEBUG"
 ulimit -n 100000
 
 
-DASK_SCHEDULER_PORT=${DASK_SCHEDULER_PORT:-8792}
 SCHEDULER_LOG=${LOGS_DIR}/scheduler_log.txt
 WORKERS_LOG=${LOGS_DIR}/worker-${HOSTNAME}_log.txt
 
@@ -107,11 +106,9 @@ function buildUCXWithInfinibandArgs {
     export DASK_UCX__RDMACM=True
     export DASK_RMM__POOL_SIZE=0.5GB
 
-    UCXPY_INTERFACE=${UCXPY_INTERFACE:-ib0}
-
     SCHEDULER_ARGS="--protocol=ucx
                 --port=$DASK_SCHEDULER_PORT
-                --interface=$UCXPY_INTERFACE
+                --interface=$DASK_CUDA_INTERFACE
                 --scheduler-file $SCHEDULER_FILE
                "
 

--- a/run-dask-process.sh
+++ b/run-dask-process.sh
@@ -29,8 +29,9 @@ function hasArg {
 VALIDARGS="-h --help scheduler workers tcp ucx ucxib ucx-ib"
 HELP="$0 [<app> ...] [<flag> ...]
  where <app> is:
-   scheduler        - start dask scheduler
-   workers          - start dask workers
+   scheduler               - start dask scheduler
+   workers                 - start dask workers
+   tcp/ucx/ucxib/ucx-ib    - communication type for cluster
  and <flag> is:
    -h | --help      - print this text
 

--- a/run-dask-process.sh
+++ b/run-dask-process.sh
@@ -14,7 +14,7 @@ ARGS=$*
 function hasArg {
     (( ${NUMARGS} != 0 )) && (echo " ${ARGS} " | grep -q " $1 ")
 }
-VALIDARGS="-h --help scheduler workers"
+VALIDARGS="-h --help scheduler workers tcp ucx ucxib ucx-ib"
 HELP="$0 [<app> ...] [<flag> ...]
  where <app> is:
    scheduler        - start dask scheduler
@@ -53,47 +53,104 @@ fi
 
 ########################################
 
-export DASK_UCX__CUDA_COPY=True
-export DASK_UCX__TCP=True
-export DASK_UCX__NVLINK=True
-export DASK_UCX__INFINIBAND=True  ###
-export DASK_UCX__RDMACM=True   ###
-export DASK_RMM__POOL_SIZE=0.5GB
-export DASK_DISTRIBUTED__COMM__TIMEOUTS__CONNECT="100s"
-export DASK_DISTRIBUTED__COMM__TIMEOUTS__TCP="600s"
-export DASK_DISTRIBUTED__COMM__RETRY__DELAY__MIN="1s"
-export DASK_DISTRIBUTED__COMM__RETRY__DELAY__MAX="60s"
-export DASK_DISTRIBUTED__WORKER__MEMORY__Terminate="False"
-
-#export DASK_UCX__REUSE_ENDPOINTS=False   ###
-export UCXPY_IFNAME="ib0"   ###
-#export UCX_NET_DEVICES=all   ###
-export UCX_MAX_RNDV_RAILS=1  # <-- must be set in the client env too!
-#export DASK_UCX_SOCKADDR_TLS_PRIORITY=sockcm   ###
-#export DASK_UCX_TLS=rc,sockcm,cuda_ipc,cuda_copy   ###
 export DASK_LOGGING__DISTRIBUTED="DEBUG"
 
 ulimit -n 100000
-export CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
 
-SCHEDULER_ARGS="--protocol=ucx
-                --port=8792
-                --interface=ib0
-                --scheduler-file $SCHEDULER_FILE
-               "
 
-WORKER_ARGS="--enable-tcp-over-ucx
-             --enable-nvlink 
-             --enable-infiniband
-             --enable-rdmacm
-             --rmm-pool-size=$WORKER_RMM_POOL_SIZE
+DASK_SCHEDULER_PORT=${DASK_SCHEDULER_PORT:-8792}
+SCHEDULER_LOG=${LOGS_DIR}/scheduler_log.txt
+WORKERS_LOG=${LOGS_DIR}/worker-${HOSTNAME}_log.txt
+
+
+function buildTcpArgs {
+    export DASK_DISTRIBUTED__COMM__TIMEOUTS__CONNECT="100s"
+    export DASK_DISTRIBUTED__COMM__TIMEOUTS__TCP="600s"
+    export DASK_DISTRIBUTED__COMM__RETRY__DELAY__MIN="1s"
+    export DASK_DISTRIBUTED__COMM__RETRY__DELAY__MAX="60s"
+    export DASK_DISTRIBUTED__WORKER__MEMORY__Terminate="False"
+
+    SCHEDULER_ARGS="--protocol=tcp
+                    --port=$DASK_SCHEDULER_PORT
+                    --scheduler-file $SCHEDULER_FILE
+                "
+
+    WORKER_ARGS="--rmm-pool-size=$WORKER_RMM_POOL_SIZE
              --local-directory=/tmp/$LOGNAME 
              --scheduler-file=$SCHEDULER_FILE
             "
-#             --net-devices=ib0
 
-SCHEDULER_LOG=${LOGS_DIR}/scheduler_log.txt
-WORKERS_LOG=${LOGS_DIR}/worker-${HOSTNAME}_log.txt
+}
+
+function buildUCXWithInfinibandArgs {
+
+    export UCX_MAX_RNDV_RAILS=1
+    export UCX_MEMTYPE_REG_WHOLE_ALLOC_TYPES=cuda
+
+    export DASK_UCX__CUDA_COPY=True
+    export DASK_UCX__TCP=True
+    export DASK_UCX__NVLINK=True
+    export DASK_UCX__INFINIBAND=True
+    export DASK_UCX__RDMACM=True
+    export DASK_RMM__POOL_SIZE=0.5GB
+
+    UCXPY_INTERFACE=${UCXPY_INTERFACE:-ib0}
+
+    SCHEDULER_ARGS="--protocol=ucx
+                --port=$DASK_SCHEDULER_PORT
+                --interface=$UCXPY_INTERFACE
+                --scheduler-file $SCHEDULER_FILE
+               "
+
+    WORKER_ARGS="--enable-tcp-over-ucx
+                --enable-nvlink
+                --enable-infiniband
+                --enable-rdmacm
+                --rmm-pool-size=$WORKER_RMM_POOL_SIZE
+                --local-directory=/tmp/$LOGNAME
+                --scheduler-file=$SCHEDULER_FILE
+                "
+}
+
+
+function buildUCXwithoutInfinibandArgs {
+
+    export UCX_TCP_CM_REUSEADDR=y
+    export UCX_MAX_RNDV_RAILS=1
+    export UCX_TCP_TX_SEG_SIZE=8M
+    export UCX_TCP_RX_SEG_SIZE=8M
+
+    export DASK_UCX__CUDA_COPY=True
+    export DASK_UCX__TCP=True
+    export DASK_UCX__NVLINK=True
+    export DASK_UCX__INFINIBAND=False
+    export DASK_UCX__RDMACM=False
+    export DASK_RMM__POOL_SIZE=0.5GB
+
+
+    SCHEDULER_ARGS="--protocol=ucx
+            --port=$DASK_SCHEDULER_PORT
+            --scheduler-file $SCHEDULER_FILE
+            "
+
+    WORKER_ARGS="--enable-tcp-over-ucx
+                --enable-nvlink
+                --disable-infiniband
+                --disable-rdmacm
+                --rmm-pool-size=$WORKER_RMM_POOL_SIZE
+                --local-directory=/tmp/$LOGNAME
+                --scheduler-file=$SCHEDULER_FILE
+                "
+}
+
+if hasArg ucx; then
+    buildUCXwithoutInfinibandArgs
+elif hasArg ucxib || hasArg ucx-ib; then
+    buildUCXWithInfinibandArgs
+else
+    buildTcpArgs
+fi
+
 
 ########################################
 

--- a/run-dask-process.sh
+++ b/run-dask-process.sh
@@ -26,14 +26,16 @@ ARGS=$*
 function hasArg {
     (( ${NUMARGS} != 0 )) && (echo " ${ARGS} " | grep -q " $1 ")
 }
-VALIDARGS="-h --help scheduler workers tcp ucx ucxib ucx-ib"
+VALIDARGS="-h --help scheduler workers --tcp --ucx --ucxib --ucx-ib"
 HELP="$0 [<app> ...] [<flag> ...]
  where <app> is:
    scheduler               - start dask scheduler
    workers                 - start dask workers
-   tcp/ucx/ucxib/ucx-ib    - communication type for cluster
  and <flag> is:
-   -h | --help      - print this text
+   --tcp                   - initalize a tcp cluster (default)
+   --ucx                   - initialize a ucx cluster with NVLink
+   --ucxib | --ucx-ib      - initialize a ucx cluster with IB+NVLink
+   -h | --help             - print this text
 
  WORKSPACE dir is: $WORKSPACE
 "
@@ -153,9 +155,9 @@ function buildUCXwithoutInfinibandArgs {
                 "
 }
 
-if hasArg ucx; then
+if hasArg --ucx; then
     buildUCXwithoutInfinibandArgs
-elif hasArg ucxib || hasArg ucx-ib; then
+elif hasArg --ucxib || hasArg --ucx-ib; then
     buildUCXWithInfinibandArgs
 else
     buildTcpArgs

--- a/wait_for_workers.py
+++ b/wait_for_workers.py
@@ -20,7 +20,38 @@ from dask.distributed import Client
 from dask_cuda.initialize import initialize
 
 
-def wait_for_workers(num_expected_workers, scheduler_file_path, timeout_after=0):
+def initialize_dask_cuda(communication_type):
+    if communication_type in ["ucxib", "ucx-ib"]:
+        initialize(
+            enable_tcp_over_ucx=True,
+            enable_nvlink=True,
+            enable_infiniband=True,
+            enable_rdmacm=True,
+        )
+    elif communication_type == "ucx":
+        initialize(
+            enable_tcp_over_ucx=True,
+            enable_nvlink=True,
+            enable_infiniband=False,
+            enable_rdmacm=False,
+        )
+    else:
+        if communication_type != "tcp":
+            print(
+                f"Communication type {communication_type} unknown, using default tcp configuration"
+            )
+
+        initialize(
+            enable_tcp_over_ucx=False,
+            enable_nvlink=False,
+            enable_infiniband=False,
+            enable_rdmacm=False,
+        )
+
+
+def wait_for_workers(
+    num_expected_workers, scheduler_file_path, communication_type, timeout_after=0
+):
     """
     Waits until num_expected_workers workers are available based on
     the workers managed by scheduler_file_path, then returns 0. If
@@ -33,30 +64,29 @@ def wait_for_workers(num_expected_workers, scheduler_file_path, timeout_after=0)
 
     print("wait_for_workers.py - initializing client...", end="")
     sys.stdout.flush()
-    initialize(
-        enable_tcp_over_ucx=True,
-        enable_nvlink=True,
-        enable_infiniband=True,
-        enable_rdmacm=True,
-    )
+    initialize_dask_cuda(communication_type)
     print("done.")
     sys.stdout.flush()
-    
+
     ready = False
     start_time = time.time()
     while not ready:
         if timeout_after and ((time.time() - start_time) >= timeout_after):
-            print(f'wait_for_workers.py timed out after {timeout_after} seconds before finding {num_expected_workers} workers.')
+            print(
+                f"wait_for_workers.py timed out after {timeout_after} seconds before finding {num_expected_workers} workers."
+            )
             sys.stdout.flush()
             break
         with Client(scheduler_file=scheduler_file_path) as client:
-            num_workers = len(client.scheduler_info()['workers'])
+            num_workers = len(client.scheduler_info()["workers"])
             if num_workers < num_expected_workers:
-                print(f'wait_for_workers.py expected {num_expected_workers} but got {num_workers}, waiting...')
+                print(
+                    f"wait_for_workers.py expected {num_expected_workers} but got {num_workers}, waiting..."
+                )
                 sys.stdout.flush()
                 time.sleep(5)
             else:
-                print(f'wait_for_workers.py got {num_workers} workers, done.')
+                print(f"wait_for_workers.py got {num_workers} workers, done.")
                 sys.stdout.flush()
                 ready = True
 
@@ -69,23 +99,46 @@ if __name__ == "__main__":
     import argparse
 
     ap = argparse.ArgumentParser()
-    ap.add_argument("--num-expected-workers", type=int, required=False,
-                    help="Number of workers to wait for. If not specified, "
-                    "uses the NUM_WORKERS env var if set, otherwise defaults "
-                    "to 16.")
-    ap.add_argument("--scheduler-file-path", type=str, required=True,
-                    help="Path to shared scheduler file to read.")
-    ap.add_argument("--timeout-after", type=int, default=0, required=False,
-                    help="Number of seconds to wait for workers. "
-                    "Default is 0 which means wait forever.")
+    ap.add_argument(
+        "--num-expected-workers",
+        type=int,
+        required=False,
+        help="Number of workers to wait for. If not specified, "
+        "uses the NUM_WORKERS env var if set, otherwise defaults "
+        "to 16.",
+    )
+    ap.add_argument(
+        "--scheduler-file-path",
+        type=str,
+        required=True,
+        help="Path to shared scheduler file to read.",
+    )
+    ap.add_argument(
+        "--communication-type",
+        type=str,
+        defualt="tcp",
+        required=False,
+        help="Initiliaze dask_cuda based on the cluster communication type."
+        "Supported values are tcp(default), ucx, ucxib, ucx-ib.",
+    )
+    ap.add_argument(
+        "--timeout-after",
+        type=int,
+        default=0,
+        required=False,
+        help="Number of seconds to wait for workers. "
+        "Default is 0 which means wait forever.",
+    )
     args = ap.parse_args()
 
     if args.num_expected_workers is None:
-        args.num_expected_workers = \
-            os.environ.get("NUM_WORKERS", 16)
-        
-    exitcode = wait_for_workers(num_expected_workers=args.num_expected_workers,
-                                scheduler_file_path=args.scheduler_file_path,
-                                timeout_after=args.timeout_after)
+        args.num_expected_workers = os.environ.get("NUM_WORKERS", 16)
+
+    exitcode = wait_for_workers(
+        num_expected_workers=args.num_expected_workers,
+        scheduler_file_path=args.scheduler_file_path,
+        communication_type=args.communication_type,
+        timeout_after=args.timeout_after,
+    )
 
     sys.exit(exitcode)

--- a/wait_for_workers.py
+++ b/wait_for_workers.py
@@ -21,6 +21,9 @@ from dask_cuda.initialize import initialize
 
 
 def initialize_dask_cuda(communication_type):
+    if "ucx" in communication_type:
+        os.environ["UCX_MAX_RNDV_RAILS"] = "1"
+
     if communication_type in ["ucxib", "ucx-ib"]:
         initialize(
             enable_tcp_over_ucx=True,
@@ -60,7 +63,6 @@ def wait_for_workers(
     """
     # FIXME: use scheduler file path from global environment if none
     # supplied in configuration yaml
-    os.environ["UCX_MAX_RNDV_RAILS"] = "1"
 
     print("wait_for_workers.py - initializing client...", end="")
     sys.stdout.flush()
@@ -116,7 +118,7 @@ if __name__ == "__main__":
     ap.add_argument(
         "--communication-type",
         type=str,
-        defualt="tcp",
+        default="tcp",
         required=False,
         help="Initiliaze dask_cuda based on the cluster communication type."
         "Supported values are tcp(default), ucx, ucxib, ucx-ib.",


### PR DESCRIPTION
Fixes #1 

- [X] Update `run-dask-process.sh` to accept an additional parameter defining the cluster type.
- [x] Update `wait-for-workers.py` to accept cluster type

**Note**: This updates the current behavior of the script where if not explicitly mentioned, the cluster type will be TCP