### PR TITLE
Initial support for CLUSTER_CONFIG_TYPE env var

### DIFF
--- a/run-py-tests.sh
+++ b/run-py-tests.sh
@@ -15,6 +15,7 @@
 RAPIDS_MG_TOOLS_DIR=${RAPIDS_MG_TOOLS_DIR:-$(cd $(dirname $0); pwd)}
 source ${RAPIDS_MG_TOOLS_DIR}/script-env.sh
 
+# FIXME: this is project-specific and should happen at the project level.
 module load cuda/11.0.3
 activateCondaEnv
 
@@ -25,9 +26,9 @@ NUM_NODES=$(python -c "from math import ceil;print(int(ceil($NUM_GPUS/float($GPU
 # used for setting CUDA_VISIBLE_DEVICES on single-node runs.
 ALL_GPU_IDS=$(python -c "print(\",\".join([str(n) for n in range($NUM_GPUS)]))")
 
-# NOTE: it's assumed TESTING_DIR has been setup elsewhere! For
+# NOTE: it's assumed TESTING_DIR has been created elsewhere! For
 # example, cronjob.sh calls this script multiple times in parallel, so
-# it may set up TESTING_DIR once ahead of time.
+# it will create, populate, etc. TESTING_DIR once ahead of time.
 
 export CUPY_CACHE_DIR=${TESTING_DIR}
 


### PR DESCRIPTION
Initial support for CLUSTER_CONFIG_TYPE env var, which overrides the default in run-dask-process.sh if set (but is overridden by the command-line options if provided).

This allows projects to set the cluster config type via their config, since they may not have direct access to all calls to `run-dask-process.sh` done from the shared mg-tools scripts.

Also updated some comments/FIXMEs.