### PR TITLE
[WIP] Minor updates to cluster startup scripts and dask process handling

### DIFF
--- a/run-cluster-dask-jobs.sh
+++ b/run-cluster-dask-jobs.sh
@@ -15,8 +15,9 @@
 RAPIDS_MG_TOOLS_DIR=${RAPIDS_MG_TOOLS_DIR:-$(cd $(dirname $0); pwd)}
 source ${RAPIDS_MG_TOOLS_DIR}/script-env.sh
 
-# FIXME: do not hardcode module load calls.
-module load cuda/11.0.3
+if hasArg --loadModule; then
+    module load cuda/11.0.3
+fi
 activateCondaEnv
 
 RUN_SCHEDULER=0
@@ -30,7 +31,7 @@ RUN_SCHEDULER=0
 # is typically run on 0 and putting the scheduler on 1 helps
 # distribute the load (I think, just based on getting OOM errors when
 # everything ran on 0).
-if [[ $SLURM_NODEID == 1 ]] || hasArg --scheduler-and-workers; then
+if [[ $SLURM_NODEID == 0 ]] || hasArg --scheduler-and-workers; then
     RUN_SCHEDULER=1
 fi
 

--- a/run-dask-process.sh
+++ b/run-dask-process.sh
@@ -82,7 +82,7 @@ fi
 
 ########################################
 
-export DASK_LOGGING__DISTRIBUTED="DEBUG"
+#export DASK_LOGGING__DISTRIBUTED="DEBUG"
 
 #ulimit -n 100000
 

--- a/run-dask-process.sh
+++ b/run-dask-process.sh
@@ -84,7 +84,7 @@ fi
 
 export DASK_LOGGING__DISTRIBUTED="DEBUG"
 
-ulimit -n 100000
+#ulimit -n 100000
 
 
 SCHEDULER_LOG=${LOGS_DIR}/scheduler_log.txt
@@ -190,7 +190,7 @@ num_scheduler_tries=0
 function startScheduler {
     mkdir -p $(dirname $SCHEDULER_FILE)
     echo "RUNNING: \"python -m distributed.cli.dask_scheduler $SCHEDULER_ARGS\"" > $SCHEDULER_LOG
-    python -m distributed.cli.dask_scheduler $SCHEDULER_ARGS >> $SCHEDULER_LOG 2>&1 &
+    dask-scheduler $SCHEDULER_ARGS >> $SCHEDULER_LOG 2>&1 &
     scheduler_pid=$!
 }
 
@@ -231,7 +231,7 @@ if [[ $START_WORKERS == 1 ]]; then
         sleep 2
     done
     echo "RUNNING: \"python -m dask_cuda.cli.dask_cuda_worker $WORKER_ARGS\"" > $WORKERS_LOG
-    python -m dask_cuda.cli.dask_cuda_worker $WORKER_ARGS >> $WORKERS_LOG 2>&1 &
+    dask-cuda-worker $WORKER_ARGS >> $WORKERS_LOG 2>&1 &
     worker_pid=$!
     echo "worker(s) started."
 fi

--- a/run-py-tests.sh
+++ b/run-py-tests.sh
@@ -86,7 +86,7 @@ for test_file in tests/dask/test_mg_*.py; do
         export SCHEDULER_FILE=$SCHEDULER_FILE
         # srun runs a task per node by default
         uniqueJobName=$(uuidgen | cut -d'-' -f1)
-        srun --export="ALL,SCRIPTS_DIR=$SCRIPTS_DIR" --job-name=$uniqueJobName --output=/dev/null ${SCRIPTS_DIR}/run-cluster-dask-jobs.sh &
+        srun --export="ALL,SCRIPTS_DIR=$SCRIPTS_DIR" --job-name=$uniqueJobName --output=/dev/null ${SCRIPTS_DIR}/run-cluster-dask-jobs.sh --loadModule &
         RUN_DASK_CLUSTER_PID=$!
         handleTimeout 120 python ${SCRIPTS_DIR}/wait_for_workers.py --num-expected-workers=$NUM_GPUS --scheduler-file-path=$SCHEDULER_FILE
         DASK_STARTUP_ERRORCODE=$LAST_EXITCODE

--- a/wait_for_workers.py
+++ b/wait_for_workers.py
@@ -21,6 +21,7 @@ from dask_cuda.initialize import initialize
 
 
 def initialize_dask_cuda(communication_type):
+    communication_type = communication_type.lower()
     if "ucx" in communication_type:
         os.environ["UCX_MAX_RNDV_RAILS"] = "1"
 


### PR DESCRIPTION
Adds some minor updates around cluster startup made while adding automation for gpu-bdb runs in this PR. https://github.com/rapidsai/workflow-performance-automation/pull/18.

Todo before merging:
- Factor out module load in all places it's being used (and confirm with other users that the change doesn't impact them)
- Make `ulimit` and debug dask logging optional (commented out right now)
- Figure out if switching from `python -m dask.scheduler` has any advantages over using it directly `Dask-scheduler`
