### PR TITLE
Reduce scale to avoid OOM

### DIFF
--- a/run-nightly-benchmarks.sh
+++ b/run-nightly-benchmarks.sh
@@ -25,7 +25,7 @@ NUM_NODES=$(python -c "from math import ceil;print(int(ceil($NUM_GPUS/float($GPU
 # Creates a string "0,1,2,3" if NUM_GPUS=4, for example, which can be
 # used for setting CUDA_VISIBLE_DEVICES on single-node runs.
 ALL_GPU_IDS=$(python -c "print(\",\".join([str(n) for n in range($NUM_GPUS)]))")
-SCALES=("17" "18" "19")
+SCALES=("9" "10" "11")
 ALGOS=(bfs sssp pagerank wcc louvain katz)
 #ALGOS=(bfs)
 SYMMETRIZED_ALGOS=(sssp wcc louvain)


### PR DESCRIPTION
This is not a fix. The scale is reduced until a more efficient resource allocation within components (scheduler, client, worker) of a node is found