### PR TITLE
Simplified the code that copies previous ASV results into the current results directory

### DIFF
--- a/create-html-reports.sh
+++ b/create-html-reports.sh
@@ -223,7 +223,7 @@ for d in "." $ALL_DIRS; do
 " >> $index
 done
 
-ASV_CONFIG_FILE=$(find ${BENCHMARK_RESULTS_DIR} -name "asv.conf.json")
+ASV_CONFIG_FILE=$(find ${BENCHMARK_RESULTS_DIR}/asv -name "asv.conf.json")
 # The asv html dir is created at the end so that an index.html is not created for it
 if [ "$ASV_CONFIG_FILE" != "" ]; then
     if hasArg --run-asv; then

--- a/functions.sh
+++ b/functions.sh
@@ -71,28 +71,16 @@ function setupResultsDir {
     mkdir -p ${RESULTS_ARCHIVE_DIR}/${DATE}
     # Store the target of $RESULTS_DIR before $RESULTS_DIR get linked to
     # a different dir 
-    PREVIOUS_RESULTS=$(readlink -f $RESULTS_DIR)
+    previous_results=$(readlink -f $RESULTS_DIR)
   
     rm -rf $RESULTS_DIR
     ln -s ${RESULTS_ARCHIVE_DIR}/${DATE} $RESULTS_DIR
     mkdir -p $TESTING_RESULTS_DIR
     mkdir -p $BENCHMARK_RESULTS_DIR
     
-    # Check if $RESULTS_DIR has a target
-    # If there is no target, This is the first run and therefore there is
-    # no asv db yet
-    if [[ $PREVIOUS_RESULTS != $RESULTS_DIR  ]]; then
-        # Copy the asv db of the previous run to the current one
-        results=$PREVIOUS_RESULTS/benchmarks/results
-        if [ -d $results ]; then
-            cp -r $results $BENCHMARK_RESULTS_DIR
-        fi
-        # This copy ensures that we get a benchmark report link irrespective
-        # of the build failing but of the previous run.
-        conf=$PREVIOUS_RESULTS/benchmarks/asv.conf.json
-        if [ -f $conf ]; then
-            cp $conf $BENCHMARK_RESULTS_DIR
-        fi
+    old_asv_dir=$previous_results/benchmarks/asv
+    if [ -d $old_asv_dir ]; then
+        cp -r $old_asv_dir $BENCHMARK_RESULTS_DIR
     fi
 }
 


### PR DESCRIPTION
Simplified the code that copies previous ASV results into the current results directory.

Manually tested by running the code and observing the `benchmarks/asv` dir was copied over from the previous run.  I did not test the case of a non-existent previous ASV dir, but the code to handle if the old dir is present was unchanged and had been tested before, so I feel comfortable with that for now.