### PR TITLE
Code cleanup, improve dump-meta-data

### DIFF
--- a/default-config.sh
+++ b/default-config.sh
@@ -28,9 +28,3 @@ DASK_CUDA_INTERFACE=${DASK_CUDA_INTERFACE:-ib0}
 DASK_SCHEDULER_PORT=${DASK_SCHEDULER_PORT:-8792}
 DASK_DEVICE_MEMORY_LIMIT=${DASK_DEVICE_MEMORY_LIMIT:-auto}
 DASK_HOST_MEMORY_LIMIT=${DASK_HOST_MEMORY_LIMIT:-auto}
-
-# Scripts in this directory use these variables which have no default and must
-# be defined by the individual projects.
-#
-# PRIMARY_CONDA_PACKAGE_NAME
-# CONDA_ENV

--- a/functions.sh
+++ b/functions.sh
@@ -173,15 +173,3 @@ wait_for_file () {
 	false
     fi
 }
-
-
-# Only define this function if it has not already been defined in the
-# current environment, which allows the project to override it from
-# its functions.sh file that was previously source'd.
-if [[ $(type -t activateCondaEnv) == "" ]]; then
-    activateCondaEnv () {
-        logger "Activating conda env ${CONDA_ENV}..."
-        eval "$(conda shell.bash hook)"
-        conda activate $CONDA_ENV
-    }
-fi

--- a/functions.sh
+++ b/functions.sh
@@ -94,19 +94,16 @@ unset_tee () {
 }
 
 # Function for running a command that gets killed after a specific timeout and
-# logs a timeout message. This also sets ERRORCODE appropriately.
+# logs a timeout message.
 LAST_EXITCODE=0
-handleTimeout () {
+handle_timeout () {
     _seconds=$1
-    eval "timeout --signal=2 --kill-after=60 $*" || LAST_EXITCODE=$?
-    ERRORCODE=${ERRORCODE:-0}
+    eval "timeout --signal=2 --kill-after=60 $*"
+    LAST_EXITCODE=$?
     if (( $LAST_EXITCODE == 124 )); then
         logger "ERROR: command timed out after ${_seconds} seconds"
     elif (( $LAST_EXITCODE == 137 )); then
         logger "ERROR: command timed out after ${_seconds} seconds, and had to be killed with signal 9"
-    fi
-    if (( ERRORCODE == 0 )); then
-        ERRORCODE=${LAST_EXITCODE}
     fi
 }
 

--- a/getopt.py
+++ b/getopt.py
@@ -23,6 +23,7 @@ echo $boo  # prints 1
 echo $baz  # prints 33
 """
 
+import builtins
 from argparse import ArgumentParser
 
 
@@ -46,6 +47,9 @@ def getopt_to_argparse(prog_name, opt_parse_string, options_list):
     arg_parser = StderrArgumentParser(prog=prog_name)
 
     for opt_desc in opt_parse_string.split(","):
+        if opt_desc == "":
+            raise RuntimeError(f"invalid option string: {opt_parse_string}")
+
         opt_desc = opt_desc.split(":")
         opt_desc_len = len(opt_desc)
         # option with no arg: "name"
@@ -56,17 +60,17 @@ def getopt_to_argparse(prog_name, opt_parse_string, options_list):
         # required arg: "name:type" or "name:"
         elif opt_desc_len == 2:
             name = f"--{opt_desc[0]}"
-            opt_type = eval(opt_desc[1] or "str")
+            opt_type = getattr(builtins, opt_desc[1] or "str")
             arg_parser.add_argument(name, type=opt_type, required=True)
 
         # optional arg: "name::type" or "name::"
         elif (opt_desc_len == 3) and (opt_desc[1] == ""):
             name = f"--{opt_desc[0]}"
-            opt_type = eval(opt_desc[2] or "str")
+            opt_type = getattr(builtins, opt_desc[2] or "str")
             arg_parser.add_argument(name, type=opt_type, required=False)
 
         else:
-            raise RuntimeError
+            raise RuntimeError(f"invalid option string: {opt_parse_string}")
     try:
         return arg_parser.parse_args(options_list)
     except SystemExit as err:

--- a/script-env.sh
+++ b/script-env.sh
@@ -20,7 +20,7 @@
 # set here.
 # Projects should always call this script to ensure a complete set of
 # script vars and functions are available.
-if [ -n "$PROJECT_DIR" ]; then
+if [ -v PROJECT_DIR ] && [ -n "$PROJECT_DIR" ]; then
     if [ -e ${PROJECT_DIR}/config.sh ]; then
 	source ${PROJECT_DIR}/config.sh
     else


### PR DESCRIPTION
This PR cleans up unused code and variables, improves the shared function for handling timeouts to not set ERRORCODE globally, and improves the script for dumping meta-data to handle an arbitrary set of packages instead of a single package specified by PRIMARY_CONDA_PACKAGE_NAME