### PR TITLE
Don't Create Separate GNN Dir

### DIFF
--- a/setup-latest-results-dir.sh
+++ b/setup-latest-results-dir.sh
@@ -47,7 +47,6 @@ fi
 latest_results_dir=${results_root_dir}/latest
 testing_results_dir=${latest_results_dir}/${TESTING_RESULTS_DIR_NAME}
 benchmark_results_dir=${latest_results_dir}/${BENCHMARK_RESULTS_DIR_NAME}
-gnn_results_dir=${latest_results_dir}/${GNN_RESULTS_DIR_NAME}
 metadata_file=${latest_results_dir}/${METADATA_FILE_NAME}
 
 mkdir -p ${results_root_dir}/${DATE}
@@ -58,7 +57,6 @@ rm -rf $latest_results_dir
 ln -s ${results_root_dir}/${DATE} $latest_results_dir
 mkdir -p $testing_results_dir
 mkdir -p $benchmark_results_dir
-mkdir -p $gnn_results_dir
 
 # copy over old regressions if they exist. otherwise, create a new directory to store them
 previous_regressions=${previous_results}/benchmarks/results

--- a/setup-latest-results-dir.sh
+++ b/setup-latest-results-dir.sh
@@ -71,7 +71,6 @@ fi
 # results dir.
 echo "TESTING_RESULTS_DIR=$testing_results_dir" >> ${latest_results_dir}/paths.sh
 echo "BENCHMARK_RESULTS_DIR=$benchmark_results_dir" >> ${latest_results_dir}/paths.sh
-echo "GNN_RESULTS_DIR=$gnn_results_dir" >> ${latest_results_dir}/paths.sh
 # The container may have a /metadata.sh file that can be sourced to set env
 # vars with info about the image that can be used in reports, etc.
 if [ -e /metadata.sh ]; then


### PR DESCRIPTION
This PR is related to [#412](https://github.com/rapidsai/graph_dl/pull/412). It changes the results-dir script to not create the `gnn` folder and move GNN results to `benchmarks`